### PR TITLE
Potential fix for code scanning alert no. 6: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Services/EtlWorkflowService.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Services/EtlWorkflowService.cs
@@ -48,7 +48,8 @@ namespace EtlOrchestrator.Infrastructure.Services
         {
             try
             {
-                _logger.LogInformation("Creando nueva definición de workflow: {Name}", name);
+                var sanitizedName = name?.Replace("\r", "").Replace("\n", "");
+                _logger.LogInformation("Creando nueva definición de workflow: {Name}", sanitizedName);
                 
                 // Validar que el JSON sea válido
                 if (!string.IsNullOrEmpty(configurationJson))


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/6](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/6)

To fix the issue, sanitize the `name` parameter before logging it. Specifically:
1. Remove any newline characters (`\n` or `\r`) from the `name` parameter to prevent log forging.
2. Use `string.Replace` to replace newline characters with an empty string.

The fix will be applied in the `CreateWorkflowDefinitionAsync` method of the `EtlWorkflowService` class, where the `name` parameter is logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
