### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Persistence/Repositories/WorkflowRepository.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Persistence/Repositories/WorkflowRepository.cs
@@ -122,7 +122,8 @@ namespace EtlOrchestrator.Infrastructure.Persistence.Repositories
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error al crear la definición de flujo de trabajo {Name}", workflowDefinition.Name);
+                var sanitizedWorkflowName = workflowDefinition.Name?.Replace("\n", "").Replace("\r", "");
+                _logger.LogError(ex, "Error al crear la definición de flujo de trabajo {Name}", sanitizedWorkflowName);
                 throw;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/1](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/1)

To fix the issue, we need to sanitize the `workflowDefinition.Name` value before logging it. Since the logs are likely plain text, we should remove any newline characters from the user input to prevent log forging. This can be achieved using `String.Replace` or a similar method to replace newline characters (`\n` and `\r`) with an empty string.

The fix will involve:
1. Sanitizing `workflowDefinition.Name` before it is passed to `_logger.LogError` on line 125 of `WorkflowRepository.cs`.
2. Ensuring that the sanitization does not alter the functionality of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
