### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Persistence/Repositories/WorkflowRepository.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Persistence/Repositories/WorkflowRepository.cs
@@ -115,8 +115,9 @@ namespace EtlOrchestrator.Infrastructure.Persistence.Repositories
                 await _context.WorkflowDefinitions.AddAsync(workflowDefinition);
                 await _context.SaveChangesAsync();
 
+                var sanitizedWorkflowName = workflowDefinition.Name?.Replace("\n", "").Replace("\r", "");
                 _logger.LogInformation("Creada definición de flujo de trabajo {Name} v{Version}", 
-                    workflowDefinition.Name, workflowDefinition.Version);
+                    sanitizedWorkflowName, workflowDefinition.Version);
 
                 return workflowDefinition;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/2](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/2)

To fix the issue, we need to ensure that the `workflowDefinition.Name` is sanitized before being logged in the `WorkflowRepository.cs` file. This involves removing newline characters (`\n` and `\r`) from the input to prevent log forging. The sanitization should be applied consistently across all log entries that use user-provided values.

The best approach is to sanitize the `workflowDefinition.Name` value immediately before logging it in the `_logger.LogInformation` call on line 119. This ensures that the logged value is safe without altering the original `workflowDefinition` object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
