### PR TITLE
Potential fix for code scanning alert no. 5: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
@@ -170,8 +170,9 @@ namespace EtlOrchestrator.Infrastructure.Scheduler
             }
             catch (Exception ex)
             {
+                var sanitizedCronExpression = cronExpression?.Replace("\n", "").Replace("\r", "");
                 _logger.LogError(ex, "Error al calcular el próximo tiempo de ejecución para la expresión cron {CronExpression}",
-                    cronExpression);
+                    sanitizedCronExpression);
                 return null;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/5](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/5)

To fix the issue, the `cronExpression` parameter should be sanitized before being logged. Specifically:
1. Remove any newline characters (`\n` or `\r`) from the `cronExpression` to prevent log forgery.
2. Optionally, encode or escape the input to ensure it is safe for logging.

The fix will involve modifying the `GetNextExecutionTime` method in `CronWorkflowScheduler.cs` to sanitize the `cronExpression` before passing it to `_logger.LogError`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
