### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
@@ -98,8 +98,10 @@ namespace EtlOrchestrator.Infrastructure.Scheduler
                     job => job.ExecuteWorkflowAsync(workflowDefinitionId, scheduleId, workflowName, inputDataJson),
                     cronExpression);
 
+                // Sanitize the cronExpression to prevent log forging
+                string sanitizedCronExpression = cronExpression.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
                 _logger.LogInformation("Workflow {WorkflowName} programado con cron {CronExpression}, jobId: {JobId}",
-                    workflowName, cronExpression, jobId);
+                    workflowName, sanitizedCronExpression, jobId);
 
                 return jobId;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/4](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/4)

To fix the issue, the `cronExpression` parameter should be sanitized before being logged. Since the log entries are plain text, we can remove newline characters and other potentially harmful characters from the `cronExpression` string. This can be achieved using `String.Replace` or similar methods.

The fix involves:
1. Sanitizing the `cronExpression` parameter in the `ScheduleWorkflow` method of `CronWorkflowScheduler.cs` before it is passed to the logger.
2. Ensuring that the sanitization does not alter the functionality of the cron expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
