### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
+++ b/src/Infrastructure/EtlOrchestrator.Infrastructure/Scheduler/CronWorkflowScheduler.cs
@@ -107,8 +107,9 @@ namespace EtlOrchestrator.Infrastructure.Scheduler
             }
             catch (Exception ex)
             {
+                string sanitizedCronExpression = cronExpression.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
                 _logger.LogError(ex, "Error al programar el workflow {WorkflowName} con cron {CronExpression}",
-                    workflowName, cronExpression);
+                    workflowName, sanitizedCronExpression);
                 throw;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/3](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/3)

To fix the issue, the `cronExpression` parameter should be sanitized consistently before being logged, including in the error-handling block. The sanitization logic already implemented on line 102 can be reused. This ensures that all log entries involving `cronExpression` are safe from log-forging attacks.

The fix involves:
1. Replacing the direct use of `cronExpression` on line 111 with a sanitized version.
2. Ensuring that the sanitization logic is applied consistently across all log statements in the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
