### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/8](https://github.com/quimalborch/EtlOrchestrator/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout@v3` step requires `contents: read` to check out the repository code.
- The `actions/upload-artifact@v4` step does not require additional permissions beyond `contents: read`.

Thus, the minimal permissions required for this workflow are `contents: read`. We will add this block at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
